### PR TITLE
Fix bug from node module dependency

### DIFF
--- a/Front/package.json
+++ b/Front/package.json
@@ -16,8 +16,8 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "export SET NODE_OPTIONS=--openssl-legacy-provider && react-scripts start",
-    "build": "export SET NODE_OPTIONS=--openssl-legacy-provider && react-scripts build",
+    "start": "react-scripts start",
+    "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
https://discord.com/channels/@me/1110937801777741897/1113473398618718381

frontend-reactjs | > export SET NODE_OPTIONS=--openssl-legacy-provider && react-scripts start
frontend-reactjs | 
frontend-reactjs | node: --openssl-legacy-provider is not allowed in NODE_OPTIONS
frontend-reactjs | npm ERR! code ELIFECYCLE
frontend-reactjs | npm ERR! errno 9
frontend-reactjs | npm ERR! bank-synthesis@0.1.0 start: `export SET NODE_OPTIONS=--openssl-legacy-provider && react-scripts start`
frontend-reactjs | npm ERR! Exit status 9
frontend-reactjs | npm ERR! 
frontend-reactjs | npm ERR! Failed at the bank-synthesis@0.1.0 start script.
frontend-reactjs | npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
frontend-reactjs | 
frontend-reactjs | npm ERR! A complete log of this run can be found in:
frontend-reactjs | npm ERR!     /root/.npm/_logs/2023-05-31T14_23_58_376Z-debug.log
